### PR TITLE
Tree sitter cleanup

### DIFF
--- a/extension/src/tree-sitter/hover/index.js
+++ b/extension/src/tree-sitter/hover/index.js
@@ -32,6 +32,10 @@ function getHoverData(language, node) {
 		return getGlobalHoverString(language, node);
 	}
 
+	if (parent.type === 'func_type_params_one') {
+		return getLocalHoverString(language, node);
+	}
+
 	if (["module_field_func", "import_desc_func_type", "func_type_params_one"].includes(parent.type)) {
 		return getFunctionHoverString(language, node);
 	}

--- a/extension/src/tree-sitter/hover/label.js
+++ b/extension/src/tree-sitter/hover/label.js
@@ -3,16 +3,23 @@ const vscode = require("vscode");
 
 const { queryWithErr, getParentNode, getIdent } = require("./utils");
 
-const labelHoverQuery = `(expr1 
-	[
-		(expr1_loop 
-			(identifier)? @ident
-		) @label_body
-		(expr1_block 
-			(identifier)? @ident
-		) @label_body
-	]
-)`;
+const labelHoverQuery = ` 
+[
+	(expr1_loop 
+		(identifier)? @ident
+	) @label_body
+	(block_loop 
+		(identifier)? @ident
+	) @label_body
+
+	(expr1_block 
+		(identifier)? @ident
+	) @label_body
+	(block_block 
+		(identifier)? @ident
+	) @label_body
+]
+`;
 
 /**
  * @param {Parser.Language} language

--- a/extension/src/tree-sitter/hover/local.js
+++ b/extension/src/tree-sitter/hover/local.js
@@ -69,7 +69,7 @@ function getLocalHoverString(language, node) {
 
 	const localType = localIdentIndex < params.length ? "param" : "local";
 	const name = typeof localIdent === "string" ? localIdent : indexToIdent.get(localIdent) ?? localIdent;
-	const hoverCode = `(${localType} ${name} (${localTypes[localIdentIndex]}))`;
+	const hoverCode = `(${localType} ${name} ${localTypes[localIdentIndex]})`;
 
 	const out = new vscode.MarkdownString();
 	out.appendCodeblock(hoverCode, "wati");

--- a/extension/src/tree-sitter/hover/table.js
+++ b/extension/src/tree-sitter/hover/table.js
@@ -21,7 +21,7 @@ function getTableHoverString(language, node) {
 
 	const moduleNode = getParentNode(node, "module");
 	if (!moduleNode) {
-		return new vscode.Hover("Could not resolve current function");
+		return new vscode.Hover("Could not resolve current module");
 	}
 
 	const matches = queryWithErr(language, tableHoverQuery, moduleNode);

--- a/extension/src/tree-sitter/hover/type.js
+++ b/extension/src/tree-sitter/hover/type.js
@@ -18,7 +18,7 @@ function getTypeHoverString(language, node) {
 
 	const moduleNode = getParentNode(node, "module");
 	if (!moduleNode) {
-		return new vscode.Hover("Could not resolve current function");
+		return new vscode.Hover("Could not resolve current module");
 	}
 
 	const matches = queryWithErr(language, typeHoverQuery, moduleNode);


### PR DESCRIPTION
### Included in this PR:
- Fixes problems from the migration PR Comment: https://github.com/NateLevin1/wati/pull/3#issuecomment-1879555821
  - functions now display the idents when available and support multi-return
  - Removed paren on local hover
  - Fix parameter hover getting caught as a function
  - Fix "block labels" not being caught as labels